### PR TITLE
Fix M3U playlist decoding

### DIFF
--- a/src/M3uPlaylistDecoder.py
+++ b/src/M3uPlaylistDecoder.py
@@ -44,20 +44,25 @@ class M3uPlaylistDecoder:
     def extractPlaylist(self,  url):
         self.log.info('Downloading playlist...')
 
-        req = urllib.request.Request(url)
-        req.add_header('User-Agent', USER_AGENT)
-        f = urllib.request.urlopen(req)
-        str = f.read()
-        f.close()
+        request = urllib.request.Request(
+            url,
+            headers={
+                'User-Agent': USER_AGENT
+            }
+        )
+
+        with urllib.request.urlopen(request) as handle:
+            encoding = handle.headers.get_content_charset() or "UTF-8"
+            content = handle.read()
 
         self.log.info('Playlist downloaded')
         self.log.info('Decoding playlist...')
 
-        lines = str.splitlines()
         playlist = []
 
-        for line in lines:
-            if line.startswith("#") == False and len(line) > 0:
+        for line in content.decode(encoding).splitlines():
+            line = line.rstrip()
+            if line and not line.startswith("#"):
                 playlist.append(line)
 
         return playlist


### PR DESCRIPTION
Reading a M3U playlist fails due to a missing decoding of the retrieved playlist content with the following exception on my system.

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/radiotray/SysTray.py", line 158, in on_start
    self.mediator.play(radio)
  File "/usr/lib/python3.6/site-packages/radiotray/StateMediator.py", line 74, in play
    self.audioPlayer.start(url)
  File "/usr/lib/python3.6/site-packages/radiotray/AudioPlayerGStreamer.py", line 69, in start
    self.playlist = self.decoder.getPlaylist(urlInfo)
  File "/usr/lib/python3.6/site-packages/radiotray/StreamDecoder.py", line 121, in getPlaylist
    return urlInfo.getDecoder().extractPlaylist(urlInfo.getUrl())
  File "/usr/lib/python3.6/site-packages/radiotray/M3uPlaylistDecoder.py", line 60, in extractPlaylist
    if line.startswith("#") == False and len(line) > 0:
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```

This should be reproducible by running radiotray on an arbitrary M3U playlist URL, e.g:

```radiotray http://lyd.nrk.no/nrk_radio_p1pluss_mp3_h.m3u```

I also would like to propose this fix for the issue.

Kindest regards,
Tobias