### PR TITLE
Add some initial explicit gi.require_version

### DIFF
--- a/data/plugins/NotificationPlugin.py
+++ b/data/plugins/NotificationPlugin.py
@@ -18,9 +18,12 @@
 #
 ##########################################################################
 
-
+import gi
 from Plugin import Plugin
+
+gi.require_version('Notify', '0.7')
 from gi.repository import Notify, GdkPixbuf
+
 from lib.common import APP_ICON, APPNAME
 from events.EventManager import EventManager
 

--- a/data/plugins/StationSwitcherPlugin.py
+++ b/data/plugins/StationSwitcherPlugin.py
@@ -20,7 +20,7 @@
 
 # author Mark F  Jan 2013
 from Plugin import Plugin
-import gtk
+from gi.repository import Gtk
 import random
 
 class StationSwitcherPlugin(Plugin):
@@ -43,13 +43,13 @@ class StationSwitcherPlugin(Plugin):
         
     def activate(self):
         # only Next >> button added to avoid cluttering menu.  Play previous can be triggered using other means
-        nextMenuItem = gtk.MenuItem("Next >>", False)
+        nextMenuItem = Gtk.MenuItem("Next >>", False)
         
         # locate the turn on/off menu item and add next button after
         i = 0
         insertIndex = 0
         for child in self.tooltip.gui.radioMenu.get_children():
-            if not isinstance(child, gtk.SeparatorMenuItem):
+            if not isinstance(child, Gtk.SeparatorMenuItem):
                 if child.get_label().startswith("Turn"): 
                     insertIndex = i+1
                     break

--- a/src/AudioPlayerGStreamer.py
+++ b/src/AudioPlayerGStreamer.py
@@ -17,8 +17,9 @@
 # along with Radio Tray.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##########################################################################
-import sys, os
+import gi, os, sys
 
+gi.require_version('Gst', '1.0')
 from gi.repository import Gst
 
 from .StreamDecoder import StreamDecoder

--- a/src/XmlDataProvider.py
+++ b/src/XmlDataProvider.py
@@ -18,10 +18,11 @@
 # along with Radio Tray.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##########################################################################
-import os
+import gi, logging, os
 from lxml import etree
+
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
-import logging
 
 class XmlDataProvider:
 


### PR DESCRIPTION
This PR adds some initial instances of `gi.require_version` so that specific requirements are imported, for example:

```
/usr/lib/python3.9/site-packages/radiotray/XmlDataProvider.py:23: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '4.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk
/usr/lib/python3.9/site-packages/radiotray/AudioPlayerGStreamer.py:22: PyGIWarning: Gst was imported without specifying a version first. Use gi.require_version('Gst', '1.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gst
```

Closes #15